### PR TITLE
Get value of enum instead of enum when setting select option

### DIFF
--- a/custom_components/xiaomi_miio/select.py
+++ b/custom_components/xiaomi_miio/select.py
@@ -71,7 +71,7 @@ class XiaomiSelect(XiaomiEntity, SelectEntity):
     async def async_select_option(self, option: str) -> None:
         """Set an option of the miio device."""
         _LOGGER.debug("Setting select value to: %s", option)
-        opt = self._choices[option]
+        opt = self._choices[option].value
         if await self._try_command(
             "Setting the select value failed",
             self._setter,


### PR DESCRIPTION
This fixes an error where that option is not JSON serializable

fixes #13