### PR TITLE
Refactor Coordinator to handle retries, defer on exceptions

### DIFF
--- a/custom_components/xiaomi_miio/coordinator.py
+++ b/custom_components/xiaomi_miio/coordinator.py
@@ -16,9 +16,14 @@ POLLING_TIMEOUT_SEC = 10
 
 _LOGGER = logging.getLogger(__name__)
 
+ALLOWED_RETRY_COUNT = 3
+
 
 class XiaomiDataUpdateCoordinator(DataUpdateCoordinator):
     """Update coordinator for xiaomi_miio."""
+
+    retry_count = -1
+    saved_state: DeviceStatus
 
     def __init__(self, hass: HomeAssistant, device: Device) -> None:
         """Initialize the coordinator."""
@@ -30,43 +35,53 @@ class XiaomiDataUpdateCoordinator(DataUpdateCoordinator):
         )
         self._device = device
 
-    # TODO: cleanup async_update_data() to allow tries to avoid code duplication
+    def __defer_or_raise(self, ex: Exception):
+        self.retry_count -= 1
+        if self.retry_count <= 0:
+            # Passtru exception to hass
+            raise ex
+        return self.saved_state
+
+    def __reset_retries(self):
+        self.retry_count = ALLOWED_RETRY_COUNT
+
     async def _async_update_data(self) -> DeviceStatus:
         """Update device."""
         # TODO: handle changed tokens by raising a ConfigEntryAuthFailed here
-        try:
-            return await self._async_fetch_data()
-        except DeviceException as ex:
-            if getattr(ex, "code", None) != -9999:
-                raise UpdateFailed(ex) from ex
-            _LOGGER.info("Got exception while fetching the state, trying again: %s", ex)
-        # Try to fetch the data a second time after error code -9999
-        try:
-            return await self._async_fetch_data()
-        except DeviceException as ex:
-            raise UpdateFailed(ex) from ex
+        for i in range(10):
+            try:
+                self.saved_state = await self._async_fetch_data()
+                self.__reset_retries()
+                return self.saved_state
+            except DeviceException as ex:
+                if getattr(ex, "code", None) == -9999:
+                    # Try to fetch the data a second time after error code -9999
+                    self.__defer_or_raise(ex) if i >= 1 else None
+                    continue
+                _LOGGER.info(
+                    "%s: Got exception while fetching the state: %s", self._device, ex
+                )
+                return self.__defer_or_raise(ex)
+            except TimeoutError as ex:
+                _LOGGER.info("%s: Got timeout while fetching the state", self._device)
+                return self.__defer_or_raise(ex)
+            # Defer on all exceptions
+            except Exception as ex:
+                return self.__defer_or_raise(ex)
+        self.__defer_or_raise(UpdateFailed("%s: Too many iterations", self._device))
 
     async def _async_fetch_data(self) -> DeviceStatus:
         """Fetch data from the device."""
-        # TODO: catch timeouterror or suppress it, as failure to do so
-        #       will cause dataupdatecoordinator to fail fetching updates?!
-        # at least the logs are filled with Got unexpected None as response
-        # for device status after a timeout..
         async with async_timeout.timeout(POLLING_TIMEOUT_SEC):
             state: DeviceStatus = await self.hass.async_add_executor_job(
                 self._device.status
             )
             if state is None:
-                _LOGGER.warning(
-                    "Got unexpected None as response for device status from %s"
+                msg = (
+                    "%s: Received unexpected None as response for device status"
                     % self._device
                 )
-                raise UpdateFailed(
-                    "Received unexpected None for device status from %s" % self._device
-                )
-                return state
-            _LOGGER.info(
-                "Got new state for %s:\n%s", self._device, state.__cli_output__
-            )
-
+                _LOGGER.warning(msg)
+                raise UpdateFailed(msg)
+            _LOGGER.info("%s: Got new state:\n%s", self._device, state.__cli_output__)
             return state


### PR DESCRIPTION
Fixes some devices becoming unavailable every 15 minutes or so often, because these devices want to connect to Xiaomi servers, but user disallowed it on network level.

I marked as draft because I want to make sure that the issue that motivated me to make this change is fixed for sure. Meaning the entities of my Air Purifier device no longer appear as unavailable for a short time in history of my Home Assistant instance.