### PR TITLE
Allow unloading config entry

### DIFF
--- a/custom_components/xiaomi_miio/__init__.py
+++ b/custom_components/xiaomi_miio/__init__.py
@@ -170,9 +170,6 @@ async def async_unload_entry(
         config_entry, platforms
     )
 
-    if unload_ok:
-        hass.data[DOMAIN].pop(config_entry.entry_id)
-
     return unload_ok
 
 


### PR DESCRIPTION
This fixes a regression after converting to use runtime_data, as there is no need to manually pop the entry from the domain data.